### PR TITLE
Use position independent code for supporting to link with shared library on 64bit Linux

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 AM_CPPFLAGS = -DSYSCONFDIR=\"${sysconfdir}\" -DLOCALSTATEDIR=\"${localstatedir}\" 
-CFLAGS += -W -Wall -Wno-unused-parameter -fno-strict-aliasing
+CFLAGS += -W -Wall -Wno-unused-parameter -fno-strict-aliasing -fPIC
 
 bin_PROGRAMS = rlogger rloggerd
 sbin_PROGRAMS = rlogd


### PR DESCRIPTION
コンパイルオプションを`-fPIC`つきにして欲しいです！MacOSXと32bit Linuxは`-fPIC`なしでも問題ないんですが、64bit LinuxでPHP extensionとリンクしようとすると下記のように怒られます。

```
/usr/bin/ld: /home/travis/build/hnw/rlogd/src/librlog.a(librlog.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/home/travis/build/hnw/rlogd/src/librlog.a: could not read symbols: Bad value
```

PHP extensionはshared libraryだから再配置可能じゃないとダメなのかと思ったんですが、MacOSXと32bit Linuxでは問題なくビルドできているので、そういう話でもなさそうですね…。
