### PR TITLE
fix uninitialised value in in_forward_setup

### DIFF
--- a/src/in_forward.c
+++ b/src/in_forward.c
@@ -259,6 +259,7 @@ in_forward_setup (struct module *module, struct dir *dir) {
     ctx->module = module;
     ctx->env.limit = DEFAULT_BUFFER_CHUNK_LIMIT;
     ctx->env.mode  = DEFAULT_SOCKET_MODE;
+    ctx->env.user = NULL;
     if (parse_params(&ctx->env, dir) == -1) {
         free(ctx);
         return -1;


### PR DESCRIPTION
before:

```
[vagrant@archlinux rlogd]$ valgrind --leak-check=full ./src/rlogd -F -c ./rlogd.conf -F -p `pwd`/tmp/run/rlogd.pid
==6107== Memcheck, a memory error detector
==6107== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==6107== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==6107== Command: ./src/rlogd -F -c ./rlogd.conf -F -p /home/vagrant/work/rlogd/tmp/run/rlogd.pid
==6107==
notice: starting rlogd 0.4.6 (rlogd.c:913)
==6107== Conditional jump or move depends on uninitialised value(s)
==6107==    at 0x405883: chperm (common.c:507)
==6107==    by 0x406E75: in_forward_setup (in_forward.c:276)
==6107==    by 0x4025FE: setup_source (rlogd.c:316)
==6107==    by 0x4025FE: setup_modules (rlogd.c:540)
==6107==    by 0x4025FE: main (rlogd.c:932)
==6107==
notice: running... (rlogd.c:948)
^Cwarning: receive signal: signum=2 (rlogd.c:575)
notice: shutting down... (rlogd.c:950)
notice: good bye (rlogd.c:955)
==6107==
==6107== HEAP SUMMARY:
==6107==     in use at exit: 0 bytes in 0 blocks
==6107==   total heap usage: 149 allocs, 149 frees, 8,445,882 bytes allocated
==6107==
==6107== All heap blocks were freed -- no leaks are possible
==6107==
==6107== For counts of detected and suppressed errors, rerun with: -v
==6107== Use --track-origins=yes to see where uninitialised values come from
==6107== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

after:

```
[vagrant@archlinux rlogd]$ valgrind --leak-check=full ./src/rlogd -F -c ./rlogd.conf -F -p `pwd`/tmp/run/rlogd.pid
==6163== Memcheck, a memory error detector
==6163== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==6163== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==6163== Command: ./src/rlogd -F -c ./rlogd.conf -F -p /home/vagrant/work/rlogd/tmp/run/rlogd.pid
==6163==
notice: starting rlogd 0.4.6 (rlogd.c:913)
notice: running... (rlogd.c:948)
^Cwarning: receive signal: signum=2 (rlogd.c:575)
notice: shutting down... (rlogd.c:950)
notice: good bye (rlogd.c:955)
==6163==
==6163== HEAP SUMMARY:
==6163==     in use at exit: 0 bytes in 0 blocks
==6163==   total heap usage: 149 allocs, 149 frees, 8,445,882 bytes allocated
==6163==
==6163== All heap blocks were freed -- no leaks are possible
==6163==
==6163== For counts of detected and suppressed errors, rerun with: -v
==6163== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
