### PR TITLE
fix Travis CI build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: c
 
+dist: xenial
+
 addons:
- apt:
-  packages:
-   - libev-dev
-   - libpcre3-dev
-   - libmsgpack-dev
+  apt:
+    sources:
+      - sourceline: 'ppa:neovim-ppa/stable'
+    packages:
+      - libev-dev
+      - libpcre3-dev
+      - libmsgpack-dev
 
 os:
   - linux


### PR DESCRIPTION
- use Xenial(Ubuntu 16.04) image
- use neovim-ppa for msgpack-c (libmsgpack-dev)